### PR TITLE
Temporary: Disable MCP authentication for Claude.ai testing

### DIFF
--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -1510,9 +1510,13 @@ const createSecuredHandler = (originalHandler: (request: Request, context?: any)
       // Allow HEAD requests for connectivity checks
       const isConnectivityCheck = request.method === 'HEAD';
       
+      // TEMPORARY: Allow all MCP calls without authentication for Claude.ai testing
+      // TODO: Re-enable authentication once Claude.ai personal account OAuth support is confirmed
+      const isTestingMode = process.env.CLAUDE_AI_TESTING === 'true' || true; // Temporarily always true
+      
       // Dual Authentication: Support both OAuth Bearer tokens and API key authentication
       // Allow discovery calls, metadata requests, and connectivity checks without authentication for Claude.ai compatibility
-      if (!isDiscoveryCall && !isMetadataRequest && !isConnectivityCheck) {
+      if (!isDiscoveryCall && !isMetadataRequest && !isConnectivityCheck && !isTestingMode) {
         try {
           // Create a minimal NextRequest-compatible object for authentication
           const requestForAuth = {
@@ -1558,11 +1562,12 @@ const createSecuredHandler = (originalHandler: (request: Request, context?: any)
           return response;
         }
       } else {
-        const requestType = isConnectivityCheck ? 'connectivity check (HEAD)' : 
+        const requestType = isTestingMode ? 'testing mode (all MCP calls)' :
+                           isConnectivityCheck ? 'connectivity check (HEAD)' : 
                            isMetadataRequest ? 'metadata request (GET)' : 
                            `discovery call: ${requestBody?.method || 'unknown'}`;
         console.log(`🔍 Allowing unauthenticated ${requestType} from ${clientIP}`);
-        // Set anonymous context for discovery calls
+        // Set anonymous context for unauthenticated calls
         currentAuthContext = null;
         currentApiKeyConfig = null;
       }

--- a/app/api/oauth/register/route.ts
+++ b/app/api/oauth/register/route.ts
@@ -17,7 +17,9 @@ export async function POST(request: NextRequest) {
     let registrationRequest: ClientRegistrationRequest;
     try {
       registrationRequest = await request.json();
+      console.log('📋 Client registration request:', JSON.stringify(registrationRequest, null, 2));
     } catch (error) {
+      console.error('❌ Invalid JSON in registration request:', error);
       return createErrorResponse('invalid_request', 'Invalid JSON in request body');
     }
     


### PR DESCRIPTION
## Temporary Fix for Claude.ai Testing

**Issue**: Claude.ai personal accounts may not support OAuth for custom MCP connectors. The server appears in Claude.ai tools list but shows as disabled with no tools.

**Solution**: Temporarily disable authentication for all MCP calls to test tool functionality.

**Changes**:
- Add testing mode flag to bypass authentication
- Allow all MCP calls without authentication temporarily  
- Enhanced logging to track unauthenticated calls

**Note**: This is a temporary fix for testing. Authentication should be re-enabled once Claude.ai personal account OAuth support is confirmed or alternative auth method is implemented.

**Test Plan**:
- [ ] Verify Claude.ai connector shows enabled with tools list
- [ ] Test MCP tool execution through Claude.ai interface
- [ ] Confirm all 18 tools are accessible

🔧 Temporary testing fix