### PR TITLE
Add OAuth protected resource metadata endpoint

### DIFF
--- a/app/api/.well-known/oauth-protected-resource/route.ts
+++ b/app/api/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,87 @@
+/**
+ * OAuth 2.0 Protected Resource Metadata Endpoint
+ * RFC 8705 - OAuth 2.0 Resource Server Metadata
+ * Tells clients where the protected MCP resources are located
+ */
+
+import { NextResponse } from 'next/server';
+import { getOAuthConfig } from '../../../../lib/oauth/config';
+
+export async function GET() {
+  try {
+    const config = getOAuthConfig();
+    
+    const metadata = {
+      // Resource server identifier
+      resource: config.issuer,
+      
+      // Authorization server that protects this resource
+      authorization_servers: [config.issuer],
+      
+      // MCP server endpoints  
+      mcp_endpoints: {
+        primary: `${config.issuer}/api/mcp`,
+        sse: `${config.issuer}/api/sse`,
+        stdio: `${config.issuer}/api/stdio`
+      },
+      
+      // Supported scopes for this resource server
+      scopes_supported: config.supportedScopes,
+      
+      // Bearer token usage
+      bearer_methods_supported: ['header'],
+      bearer_locations_supported: ['authorization'],
+      
+      // Resource server capabilities
+      capabilities: {
+        tools: 18,
+        resources: true,
+        prompts: true,
+        notifications: false,
+        progress: false,
+        logging: true
+      },
+      
+      // Service information
+      service_documentation: `${config.issuer}/docs`,
+      service_name: 'Industrial MCP Server',
+      service_version: '2.0.0',
+      
+      // Database information
+      databases: [
+        {
+          type: 'Neo4j',
+          name: 'Knowledge Graph',
+          description: 'Industrial/operational data and organizational structures'
+        },
+        {
+          type: 'MySQL',
+          name: 'Analytics Database', 
+          description: 'Matomo web analytics and visitor intelligence'
+        }
+      ]
+    };
+    
+    console.log('📋 Serving MCP Protected Resource Metadata');
+    
+    return NextResponse.json(metadata, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=3600', // Cache for 1 hour
+      }
+    });
+  } catch (error) {
+    console.error('❌ Error serving protected resource metadata:', error);
+    
+    return NextResponse.json({
+      error: 'server_error',
+      error_description: 'Failed to retrieve protected resource metadata'
+    }, { 
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Add missing OAuth 2.0 protected resource metadata endpoint that tells Claude.ai where to make authenticated MCP requests after successful OAuth flow.

## Problem
- OAuth flow completes successfully (token issued)  
- Claude.ai shows "Successfully connected to IMCP" tooltip
- But Connect button still shows "Disconnected"
- No authenticated MCP requests made to /api/mcp
- Claude.ai doesn't know where the MCP server endpoints are located

## Solution
- Create /.well-known/oauth-protected-resource endpoint per RFC 8705
- Specify MCP server endpoints (mcp, sse, stdio) for Claude.ai
- Include resource server capabilities and supported scopes
- Tell Claude.ai exactly where to make authenticated requests

## Changes
- New protected resource metadata endpoint
- MCP endpoint discovery for OAuth clients
- Resource server capability advertisement
- Database and service information

## Testing
After this fix, Claude.ai should:
1. ✅ Complete OAuth flow (already working)
2. ✅ Discover MCP endpoints from protected resource metadata  
3. ✅ Make authenticated POST requests to /api/mcp with Bearer token
4. ✅ Show "Connected" status and enable MCP tools in chat