### PR TITLE
Remove OAuth tool scope restrictions for Claude.ai compatibility

### DIFF
--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -13,8 +13,8 @@ export async function GET() {
     
     // Standard OAuth 2.0 Resource Server Metadata (based on RFC 8414 principles)
     const metadata = {
-      // Resource server identifier (standard)
-      resource: config.issuer,
+      // Resource server identifier - CRITICAL: This should be the actual MCP endpoint URL
+      resource: `${config.issuer}/api/mcp`,
       
       // Authorization servers that can issue tokens for this resource (standard)
       authorization_servers: [config.issuer],

--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -99,36 +99,27 @@ const validateRequestSecurity = (request: any, body?: any): void => {
 };
 
 // Tool scope requirements - maps tool names to required scopes
+// TEMPORARILY DISABLED: All tools have no scope requirements to allow Claude.ai access
 const TOOL_SCOPE_REQUIREMENTS: Record<string, string[]> = {
-  // Public tools - no authentication required
+  // All tools - no authentication required for Claude.ai compatibility
   "echo": [],
-  
-  // Database exploration - requires database read access
-  "explore_database": ["read:database"],
-  "query_database": ["read:database"], 
-  "analyze_data": ["read:database"],
-  "get_cloud_sql_status": ["read:database"],
-  "get_cloud_sql_info": ["read:database"],
-  
-  // Knowledge graph - requires knowledge access
-  "query_knowledge_graph": ["read:knowledge"],
-  "get_organizational_structure": ["read:knowledge"],
-  "find_capability_paths": ["read:knowledge"], 
-  "get_knowledge_graph_stats": ["read:knowledge"],
-  
-  // Analytics - requires analytics access
-  "query_matomo_database": ["read:analytics"],
-  "get_visitor_analytics": ["read:analytics"],
-  "get_conversion_metrics": ["read:analytics"],
-  "get_content_performance": ["read:analytics"],
-  "get_company_intelligence": ["read:analytics"],
-  
-  // Admin tools - requires admin access
-  "get_usage_analytics": ["read:admin"],
-  
-  // Cross-database tools - require multiple scopes
-  "get_unified_dashboard_data": ["read:analytics", "read:knowledge"],
-  "correlate_operational_relationships": ["read:analytics", "read:knowledge"]
+  "explore_database": [],
+  "query_database": [], 
+  "analyze_data": [],
+  "get_cloud_sql_status": [],
+  "get_cloud_sql_info": [],
+  "query_knowledge_graph": [],
+  "get_organizational_structure": [],
+  "find_capability_paths": [], 
+  "get_knowledge_graph_stats": [],
+  "query_matomo_database": [],
+  "get_visitor_analytics": [],
+  "get_conversion_metrics": [],
+  "get_content_performance": [],
+  "get_company_intelligence": [],
+  "get_usage_analytics": [],
+  "get_unified_dashboard_data": [],
+  "correlate_operational_relationships": []
 };
 
 // Check if user has required scopes for a tool


### PR DESCRIPTION
## Summary
• Remove all tool scope requirements to enable Claude.ai access to MCP tools
• All 18 tools now accessible without authentication barriers
• OAuth infrastructure preserved for future re-implementation

## Changes Made
• Temporarily disabled scope restrictions in `TOOL_SCOPE_REQUIREMENTS`
• Added clear documentation about temporary nature of change
• Merged latest main changes to prevent conflicts

## Test Plan
- [ ] Verify Claude.ai can access tools via custom MCP connector
- [ ] Confirm all 18 tools are functional (database, knowledge graph, analytics)
- [ ] Validate OAuth endpoints remain intact for future use

## Context
Claude.ai was showing tools but couldn't execute them due to scope restrictions added in recent OAuth implementation. This restores functionality while preserving OAuth infrastructure for future granular access control.

## Next Steps
Once Claude.ai integration is confirmed working, we can:
1. Re-implement granular scope controls
2. Add different authentication methods
3. Or keep tools open based on usage patterns