### PR TITLE
Fix Matomo analytics tools MySQL connection issues

### DIFF
--- a/app/api/mcp/tools/cross-database-tools.ts
+++ b/app/api/mcp/tools/cross-database-tools.ts
@@ -50,7 +50,7 @@ export async function getUnifiedDashboardData(options: UnifiedDashboardOptions =
     // Get web analytics data from MySQL (Matomo)
     if (include_web_analytics) {
       try {
-        const mysqlConnection = dbManager.getConnection('mysql')
+        const mysqlConnection = dbManager.getConnection() // Use default connection
         if (mysqlConnection.type === 'mysql') {
           results.data_sources.push('mysql_analytics')
           
@@ -291,7 +291,7 @@ export async function correlateOperationalRelationships(options: OperationalCorr
           const companyResult = await neo4jConnection.query(companyQuery, companyParams)
           
           // For each company found, try to get web analytics data
-          const mysqlConnection = dbManager.getConnection('mysql')
+          const mysqlConnection = dbManager.getConnection() // Use default connection
           if (mysqlConnection.type === 'mysql' && companyResult.data) {
             for (const company of companyResult.data) {
               try {
@@ -406,7 +406,7 @@ async function correlateGeographicData(dbManager: any, options: { date_range: st
     const locationResult = await neo4jConnection.query(locationQuery, { limit: options.limit })
     
     // Get geographic distribution from MySQL (Matomo)
-    const mysqlConnection = dbManager.getConnection('mysql')
+    const mysqlConnection = dbManager.getConnection() // Use default connection
     const dateCondition = options.date_range === 'last_7_days' 
       ? 'visit_first_action_time >= DATE_SUB(NOW(), INTERVAL 7 DAY)'
       : 'visit_first_action_time >= DATE_SUB(NOW(), INTERVAL 30 DAY)'
@@ -466,7 +466,7 @@ async function correlateGeographicData(dbManager: any, options: { date_range: st
  */
 async function correlateVisitorToEntity(dbManager: any, options: { website_domain: string; date_range: string; limit: number }) {
   try {
-    const mysqlConnection = dbManager.getConnection('mysql')
+    const mysqlConnection = dbManager.getConnection() // Use default connection
     const dateCondition = options.date_range === 'last_7_days' 
       ? 'lv.visit_first_action_time >= DATE_SUB(NOW(), INTERVAL 7 DAY)'
       : 'lv.visit_first_action_time >= DATE_SUB(NOW(), INTERVAL 30 DAY)'

--- a/app/api/mcp/tools/mysql-analytics-tools.ts
+++ b/app/api/mcp/tools/mysql-analytics-tools.ts
@@ -59,7 +59,7 @@ export async function queryMatomoDatabase(options: MatomoQueryOptions) {
     const validatedParameters = ValidationUtils.validateSqlParameters(parameters)
     
     const dbManager = await getGlobalDatabaseManager()
-    const connection = dbManager.getConnection('mysql')
+    const connection = dbManager.getConnection() // Use default connection
     
     if (connection.type !== 'mysql') {
       throw new Error('MySQL connection required for Matomo analytics')
@@ -117,7 +117,7 @@ export async function getVisitorAnalytics(options: VisitorAnalyticsOptions = {})
     
     const { date_range = 'last_7_days', site_id, limit = 100 } = validatedInput
     const dbManager = await getGlobalDatabaseManager()
-    const connection = dbManager.getConnection('mysql')
+    const connection = dbManager.getConnection() // Use default connection
     
     if (connection.type !== 'mysql') {
       throw new Error('MySQL connection required for visitor analytics')
@@ -234,7 +234,7 @@ export async function getConversionMetrics(options: ConversionMetricsOptions = {
   
   try {
     const dbManager = await getGlobalDatabaseManager()
-    const connection = dbManager.getConnection('mysql')
+    const connection = dbManager.getConnection() // Use default connection
     
     if (connection.type !== 'mysql') {
       throw new Error('MySQL connection required for conversion metrics')
@@ -345,7 +345,7 @@ export async function getContentPerformance(options: ContentPerformanceOptions =
   
   try {
     const dbManager = await getGlobalDatabaseManager()
-    const connection = dbManager.getConnection('mysql')
+    const connection = dbManager.getConnection() // Use default connection
     
     if (connection.type !== 'mysql') {
       throw new Error('MySQL connection required for content performance')
@@ -478,7 +478,7 @@ export async function getCompanyIntelligence(options: CompanyIntelligenceOptions
   
   try {
     const dbManager = await getGlobalDatabaseManager()
-    const connection = dbManager.getConnection('mysql')
+    const connection = dbManager.getConnection() // Use default connection
     
     if (connection.type !== 'mysql') {
       throw new Error('MySQL connection required for company intelligence')


### PR DESCRIPTION
## Summary
• Fix MySQL connection lookup in Matomo analytics tools 
• Remove hardcoded 'mysql' parameter to work with Cloud SQL configurations
• All 6 failing Matomo tools now use default connection properly

## Root Cause
The Matomo analytics tools were failing because they were calling `getConnection('mysql')` but the actual MySQL connections in production are named:
- `cloud_sql_primary` (production)
- `cloud_sql_staging` (staging) 
- `cloudsql_connector` (serverless)

## Changes Made
**Files Updated:**
- `app/api/mcp/tools/mysql-analytics-tools.ts` (5 functions)
- `app/api/mcp/tools/cross-database-tools.ts` (4 functions)

**Fix Applied:**
```typescript
// Before
const connection = dbManager.getConnection('mysql')

// After  
const connection = dbManager.getConnection() // Use default connection
```

## Tools Fixed
- ✅ `query_matomo_database` - Direct Matomo queries
- ✅ `get_visitor_analytics` - Visitor behavior data
- ✅ `get_conversion_metrics` - Goal tracking
- ✅ `get_content_performance` - Page performance  
- ✅ `get_company_intelligence` - B2B visitor data
- ✅ `correlate_operational_relationships` - Cross-database correlations

## Test Plan
- [ ] Deploy to production
- [ ] Test Claude.ai access to all Matomo analytics tools
- [ ] Verify tools can connect to Cloud SQL database
- [ ] Confirm all 18 MCP tools are functional

## Context
Claude.ai reported these 6 tools as inaccessible due to MySQL connection errors. The database manager correctly configures default connections to point to the appropriate Cloud SQL instance, but tools were bypassing this by requesting a specific 'mysql' connection name that doesn't exist.