### PR TITLE
Fix MySQL parameter count mismatch and SQL syntax errors

### DIFF
--- a/app/api/mcp/tools/cloud-sql-status.ts
+++ b/app/api/mcp/tools/cloud-sql-status.ts
@@ -76,7 +76,7 @@ export async function getCloudSQLStatus(params: CloudSQLStatusParams = {}) {
           
           // Get basic connection info
           const connectionInfo = await connection.query(
-            `SELECT CONNECTION_ID() as connection_id, USER() as current_user, DATABASE() as current_database, VERSION() as mysql_version, @@ssl_cipher as ssl_cipher, NOW() as server_time`
+            `SELECT CONNECTION_ID() as connection_id, USER() as currentuser, DATABASE() as current_database, VERSION() as mysql_version, @@ssl_cipher as ssl_cipher, NOW() as server_time`
           )
           
           if (connectionInfo.success && connectionInfo.data?.[0]) {

--- a/app/api/mcp/tools/mysql-analytics-tools.ts
+++ b/app/api/mcp/tools/mysql-analytics-tools.ts
@@ -188,7 +188,9 @@ export async function getVisitorAnalytics(options: VisitorAnalyticsOptions = {})
       ${whereClause}
     `
     
-    const summaryResult = await connection.query(summaryQuery, parameters.slice(0, -1))
+    // Create separate parameters array for summary query (exclude the LIMIT parameter)
+    const summaryParameters = site_id ? [site_id] : []
+    const summaryResult = await connection.query(summaryQuery, summaryParameters)
     
     // Convert null values to numbers for validation
     const summaryData = summaryResult.data?.[0] || {}
@@ -313,7 +315,11 @@ export async function getConversionMetrics(options: ConversionMetricsOptions = {
       ${whereClause.replace('c.idsite', 'idsite')}
     `
     
-    const summaryResult = await connection.query(summaryQuery, parameters.slice(0, -1))
+    // Create separate parameters array for summary query (exclude the LIMIT parameter)
+    const summaryParameters = []
+    if (site_id) summaryParameters.push(site_id)
+    if (goal_id) summaryParameters.push(goal_id)
+    const summaryResult = await connection.query(summaryQuery, summaryParameters)
     
     return {
       success: true,
@@ -595,7 +601,13 @@ export async function getCompanyIntelligence(options: CompanyIntelligenceOptions
       ${whereClause}
     `
     
-    const summaryResult = await connection.query(summaryQuery, parameters.slice(0, -1))
+    // Create separate parameters array for summary query (exclude the LIMIT parameter)
+    const summaryParameters = []
+    if (site_id) summaryParameters.push(site_id)
+    if (company_name) summaryParameters.push(`%${company_name}%`)
+    if (domain) summaryParameters.push(`%${domain}%`)
+    if (country) summaryParameters.push(country)
+    const summaryResult = await connection.query(summaryQuery, summaryParameters)
     
     return {
       success: true,


### PR DESCRIPTION
## Summary
Additional fixes for MySQL query execution errors identified after PR #39 deployment. Resolves parameter count mismatches that were causing `mysqld_stmt_execute` errors in analytics tools.

## Issues Resolved

### MySQL Parameter Count Mismatch ✅
- **Root Cause**: Using `parameters.slice(0, -1)` created parameter count mismatches when optional parameters weren't provided
- **Error**: `Incorrect arguments to mysqld_stmt_execute` in analytics queries
- **Solution**: Created explicit `summaryParameters` arrays that exactly match query placeholders

### Affected Tools Fixed:
- ✅ `get_visitor_analytics` - Fixed parameter handling for site_id
- ✅ `get_conversion_metrics` - Fixed parameters for site_id and goal_id  
- ✅ `get_company_intelligence` - Fixed parameters for site_id, company_name, domain, country

### SQL Syntax Error ✅
- ✅ `get_cloud_sql_status` - Fixed column reference from 'current_user' to 'currentuser'

## Technical Details
**Before**: `parameters.slice(0, -1)` removed LIMIT parameter but could create empty arrays
**After**: Explicit parameter arrays built only with values that have corresponding placeholders

Example fix in `get_visitor_analytics`:
```javascript
// Before (problematic)
const summaryResult = await connection.query(summaryQuery, parameters.slice(0, -1))

// After (fixed)
const summaryParameters = site_id ? [site_id] : []
const summaryResult = await connection.query(summaryQuery, summaryParameters)
```

## Test Plan
- [x] Parameter count now matches placeholder count in all summary queries
- [x] Analytics tools handle optional parameters correctly
- [x] SQL syntax errors eliminated in connection status queries

Ready for production deployment to resolve remaining MCP tool execution errors.