### PR TITLE
Fix column reference mapping in cloud SQL status details

### DIFF
--- a/app/api/mcp/tools/cloud-sql-status.ts
+++ b/app/api/mcp/tools/cloud-sql-status.ts
@@ -83,7 +83,7 @@ export async function getCloudSQLStatus(params: CloudSQLStatusParams = {}) {
             const info = connectionInfo.data[0]
             results.databases[connectionName].details = {
               connection_id: info.connection_id,
-              current_user: info.current_user,
+              current_user: info.currentuser,
               current_database: info.current_database, 
               mysql_version: info.mysql_version,
               ssl_cipher: info.ssl_cipher,


### PR DESCRIPTION
## Summary
Fix column reference inconsistency in `get_cloud_sql_status` tool that was causing incorrect property mapping in connection details.

## Issue Resolved
- **Problem**: Mismatch between SQL column alias and object property reference
- **SQL Query**: Uses `USER() as currentuser` 
- **Object Mapping**: Was incorrectly referencing `info.current_user` instead of `info.currentuser`
- **Result**: Connection details were not displaying user information correctly

## Fix Applied ✅
**Before**:
```javascript
current_user: info.current_user,  // undefined - wrong property name
```

**After**:
```javascript  
current_user: info.currentuser,   // correct - matches SQL alias
```

## Impact
- ✅ Cloud SQL connection details now properly display current user information
- ✅ Eliminates undefined values in connection status responses
- ✅ Improves MCP tool reliability and debugging information

## Test Plan
- [x] SQL column alias matches object property reference
- [x] Connection details display user information correctly
- [x] No undefined values in status responses

Small but important fix for proper connection status reporting.